### PR TITLE
Point to correct elm/npm packages instead of elm-graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `elm-oembed`
 
-[![Elm package](https://img.shields.io/elm-package/v/dillonkearns/elm-graphql.svg)](https://package.elm-lang.org/packages/dillonkearns/elm-graphql/latest/)
-[![npm](https://img.shields.io/npm/v/@dillonkearns/elm-graphql.svg)](https://npmjs.com/package/@dillonkearns/elm-graphql)
+[![Elm package](https://img.shields.io/elm-package/v/dillonkearns/elm-oembed.svg)](https://package.elm-lang.org/packages/dillonkearns/elm-oembed/latest/)
+[![npm](https://img.shields.io/npm/v/elm-oembed.svg)](https://npmjs.com/package/elm-oembed)
 
 A Web Component and accompanying Elm package for rendering [oembed content](https://oembed.com).
 


### PR DESCRIPTION
The current README points to `elm-graph` elm/npm packages instead of `elm-oembed`.